### PR TITLE
Add docker-compose.yaml file to ease development

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  db:
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+      MYSQL_DATABASE: homestead
+      MYSQL_USER: homestead
+      MYSQL_PASSWORD: secret
+  web:
+    build: .
+    ports:
+        - 9000:9000
+        - 3000:80


### PR DESCRIPTION
Hello, 
This is to add a docker-compose.yaml which spins a local mysql db which matches the .env.example file so it's easier to do development.